### PR TITLE
Fix ci release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,9 @@ jobs:
             -f tag_name="${RELEASE_VERSION}" \
             --jq ".body" > "${CHANGELOG_FILE}"
 
-          cat "${CHANGELOG_FILE}"
-          ls -la **/build/libs/spark-1.*-*.jar
-          echo "gh release create \"${RELEASE_VERSION}\" -F \"${CHANGELOG_FILE}\" $PRERELEASE **/build/libs/spark-1.*-*.jar"
-
+          echo "Running release for: gh release create \"${RELEASE_VERSION}\" -F \"${CHANGELOG_FILE}\" $PRERELEASE **/build/libs/spark-1.*-*.jar"
           gh release create "${RELEASE_VERSION}" -F "${CHANGELOG_FILE}" $PRERELEASE **/build/libs/spark-1.*-*.jar
         shell: bash
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_DEBUG: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,13 @@ jobs:
 
       - name: Delete old release if it already exists
         run: gh release delete --yes "${RELEASE_VERSION}"
+        if: matrix.os == 'ubuntu-latest'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release under current tag
+        if: matrix.os == 'ubuntu-latest'
         run: |
           PRERELEASE=""
           if [[ "$SNAPSHOT" == "true" ]]; then
@@ -75,9 +77,14 @@ jobs:
             "/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
             -f tag_name="${RELEASE_VERSION}" \
             --jq ".body" > "${CHANGELOG_FILE}"
+
           cat "${CHANGELOG_FILE}"
+          ls -la **/build/libs/spark-1.*-*.jar
+          echo "gh release create \"${RELEASE_VERSION}\" -F \"${CHANGELOG_FILE}\" $PRERELEASE **/build/libs/spark-1.*-*.jar"
+
           gh release create "${RELEASE_VERSION}" -F "${CHANGELOG_FILE}" $PRERELEASE **/build/libs/spark-1.*-*.jar
         shell: bash
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_DEBUG: 1


### PR DESCRIPTION
This just limits the release jobs to ubuntu, preventing the longer running windows job from deleting the release and then not uploading anything..