### PR TITLE
Adapt release so we also include the dev jars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: jars
           path: |
-            **/build/libs/spark-1.*-*.jar
+            **/build/libs/spark-*.jar
 
       - name: Delete old release if it already exists
         run: gh release delete --yes "${RELEASE_VERSION}"
@@ -78,8 +78,8 @@ jobs:
             -f tag_name="${RELEASE_VERSION}" \
             --jq ".body" > "${CHANGELOG_FILE}"
 
-          echo "Running release for: gh release create \"${RELEASE_VERSION}\" -F \"${CHANGELOG_FILE}\" $PRERELEASE **/build/libs/spark-1.*-*.jar"
-          gh release create "${RELEASE_VERSION}" -F "${CHANGELOG_FILE}" $PRERELEASE **/build/libs/spark-1.*-*.jar
+          echo "Running release for: gh release create \"${RELEASE_VERSION}\" -F \"${CHANGELOG_FILE}\" $PRERELEASE **/build/libs/spark-*.jar"
+          gh release create "${RELEASE_VERSION}" -F "${CHANGELOG_FILE}" $PRERELEASE **/build/libs/spark-*.jar
         shell: bash
         continue-on-error: true
         env:

--- a/spark-forge1710/build.gradle
+++ b/spark-forge1710/build.gradle
@@ -73,7 +73,8 @@ shadowJar {
 }
 
 tasks.named("reobfJar", ReobfuscatedJar) {
-    archiveFileName = "spark-${project.pluginVersion}-forge-1.7.10.jar"
+    archiveBaseName = project.name
+    archiveVersion = project.version
     inputJar.set(tasks.named("shadowJar", ShadowJar).map { it.archiveFile }.get())
 }
 


### PR DESCRIPTION
This PR adapts the release action and the build action to also include the dev & fat-dev jars, so they can be used in other projects via IVY (and maven if someone wants to setup the nexus for this repo :doom:).